### PR TITLE
Se corrige error en instalación con versiones modernas de PHP

### DIFF
--- a/modules/installer/controller/setup.php
+++ b/modules/installer/controller/setup.php
@@ -125,7 +125,7 @@ class setup extends Controller
             $config['app']['name'] = $_POST['site_name'];
             $config['app']['debug'] = $_POST['debug']?true:false;
             $config['app']['ssl'] = $_POST['ssl']?true:false;
-            $config['app'] = array_merge($config['app'], $_POST['settings']);
+            $config['app'] = array_merge($config['app'], $_POST['settings']??[]);
             if($this->saveConfig($config))
             {
                 return true;


### PR DESCRIPTION
Al ejecutar el installer se produce un error en la función array_merge que espera un 2º parámetro como array y recibe null. Se corrige el error.